### PR TITLE
Cater for names without `typenum::` qualification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ enum Term {
 
 named!(bit<&str, Bit>,
        preceded!(
-           alt_complete!(tag!("typenum::B") | tag!("typenum::bit::B")),
+           alt_complete!(tag!("B") | tag!("typenum::B") | tag!("typenum::bit::B")),
            alt!(
                value!(Bit::B0, tag!("0")) | value!(Bit::B1, tag!("1"))
            )
@@ -54,10 +54,10 @@ named!(bit<&str, Bit>,
 named!(unsigned<&str, Unsigned>,
        alt!(
            value!(Unsigned::UTerm,
-                  alt_complete!(tag!("typenum::UTerm") | tag!("typenum::uint::UTerm")))
+                  alt_complete!(tag!("UTerm") | tag!("typenum::UTerm") | tag!("typenum::uint::UTerm")))
                |
            delimited!(
-               alt_complete!(tag!("typenum::UInt<") | tag!("typenum::uint::UInt<")),
+               alt_complete!(tag!("UInt<") | tag!("typenum::UInt<") | tag!("typenum::uint::UInt<")),
                map!(
                    separated_pair!(unsigned, tag!(", "), bit),
                    Unsigned::from_tuple


### PR DESCRIPTION
The parser was searching for items qualified with either `typenum::`, `typenum::uint` or `typenum::bit`.

In a current version of `typenum` I'm getting error messages where the `typenum` names appear without qualification.

This change adds matches for the unqualified names too. It appears to work in the few use-cases I have tried.

I guess that, without qualification, it's likely to pick up some false positives: names which come from code unrelated to `typenum`. But that probably doesn't matter too much, as 

+ the context should cause a mismatch,
+ messing up other parts of the error message while clearing up the `typenum` bit, can still be useful for an *optional* tool.